### PR TITLE
Update erpnext apps logo to dutlabs logo

### DIFF
--- a/dutlabs_theme/setup/install.py
+++ b/dutlabs_theme/setup/install.py
@@ -60,18 +60,26 @@ def add_navbar_items():
 
 def add_app_name():
     frappe.db.set_single_value("Website Settings", "app_name", "Dut ERP")
-	
+
 def add_app_logo():
     frappe.db.set_single_value("Website Settings", "app_logo", "/assets/dutlabs_theme/images/dutlabs-logo.png")
 
 def disable_system_update_notification():
 	frappe.db.set_single_value(SYSTEM_SETTINGS, "disable_system_update_notification", 1)
 
+def update_erpnext_logo():
+	import shutil
+	shutil.copyfile(
+		"./assets/dutlabs_theme/images/dutlabs-logo.png",
+		"./assets/erpnext/images/erpnext-logo-blue.png",
+	)
+
 def after_install():
 	remove_navbar_items()
 	add_navbar_items()
 	add_app_name()
 	add_app_logo()
+	update_erpnext_logo()
 	disable_system_update_notification()
 
 	frappe.clear_cache()


### PR DESCRIPTION
This commit adds a function to replace the original erpnext logo in apps page to dutlabs logo through the hooks functions.

It is a temp workaround solution to avoid override code.